### PR TITLE
Fix chat enter key handler

### DIFF
--- a/website/app/components/Chat.tsx
+++ b/website/app/components/Chat.tsx
@@ -90,7 +90,7 @@ export default function Chat() {
             value={inputText}
             onChange={(e) => setInputText(e.target.value)}
             placeholder="Type your message..."
-            onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
+            onKeyDown={(e) => e.key === "Enter" && handleSendMessage()}
             disabled={isLoading}
           />
           <CustomButton


### PR DESCRIPTION
## Summary
- ensure chat input sends message on Enter key press by switching to `onKeyDown`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` in backend *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_683ff2bd19f0832bbe31128a2897f848